### PR TITLE
disable volumes for now. works on linux but not on windows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
     depends_on:
       - mongo
     command: ["npm", "run", "${NPM_CMD:-start}"]
-    volumes:
-      - ./src/:/usr/src/app/src/
+#    volumes:
+#      - ./src/:/usr/src/app/src/
 
   mongo:
     container_name: mongo


### PR DESCRIPTION
Bastian Böhm, [02.12.19 13:54]
If you are still facing the issue, try the same set of commands to mount the drives using Powershell CLI and it'll prompt you to allow shared drives post which you'll be able to mount drives to containers with ease.

Bastian Böhm, [02.12.19 13:56]
falls das funktioniert sollten wir das in die readme aufnehmen